### PR TITLE
Upgrade to Cog version 0.1

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -1,210 +1,187 @@
-# Prediction interface for Cog ⚙️
-# Reference: https://github.com/replicate/cog/blob/main/docs/python.md
-
 import os
 import tempfile
-from copy import deepcopy
-from pathlib import Path
-
-import cog
+from cog import BasePredictor, Input, Path
+import shutil
+from argparse import Namespace
+import time
+import sys
+import pprint
 import numpy as np
-import torch
 from PIL import Image
-from torch import optim
-from torch.nn import functional as F
-from torchvision import transforms
-from tqdm import tqdm
+import torch
+import torchvision.transforms as transforms
+import dlib
 
-from e4e_projection import projection as e4e_projection
-from model import Discriminator, Generator
-from util import align_face
+sys.path.append(".")
+sys.path.append("..")
+
+from datasets import augmentations
+from utils.common import tensor2im, log_input_image
+from models.psp import pSp
+from scripts.align_all_parallel import align_face
 
 
-class Predictor(cog.Predictor):
+class Predictor(BasePredictor):
     def setup(self):
-        pass
+        self.predictor = dlib.shape_predictor("shape_predictor_68_face_landmarks.dat")
+        model_paths = {
+            "ffhq_frontalize": "pretrained_models/psp_ffhq_frontalization.pt",
+            "celebs_sketch_to_face": "pretrained_models/psp_celebs_sketch_to_face.pt",
+            "celebs_super_resolution": "pretrained_models/psp_celebs_super_resolution.pt",
+            "toonify": "pretrained_models/psp_ffhq_toonify.pt",
+        }
 
-    @cog.input("input_face", type=Path, help="Photo of human face")
-    @cog.input(
-        "pretrained",
-        type=str,
-        default=None,
-        help="Identifier of pretrained style",
-        options=[
-            "art",
-            "arcane_multi",
-            "sketch_multi",
-            "arcane_jinx",
-            "arcane_caitlyn",
-            "jojo_yasuho",
-            "jojo",
-            "disney",
-        ],
-    )
-    @cog.input("style_img_0", default=None, type=Path, help="Face style image (unused if pretrained style is set)")
-    @cog.input("style_img_1", default=None, type=Path, help="Face style image (optional)")
-    @cog.input("style_img_2", default=None, type=Path, help="Face style image (optional)")
-    @cog.input("style_img_3", default=None, type=Path, help="Face style image (optional)")
-    @cog.input(
-        "preserve_color",
-        default=False,
-        type=bool,
-        help="Preserve the colors of the original image",
-    )
-    @cog.input(
-        "num_iter", default=200, type=int, min=0, help="Number of finetuning steps (unused if pretrained style is set)"
-    )
-    @cog.input(
-        "alpha", default=1, type=float, min=0, max=1, help="Strength of finetuned style"
-    )
+        loaded_models = {}
+        for key, value in model_paths.items():
+            loaded_models[key] = torch.load(value, map_location="cpu")
+
+        self.opts = {}
+        for key, value in loaded_models.items():
+            self.opts[key] = value["opts"]
+
+        for key in self.opts.keys():
+            self.opts[key]["checkpoint_path"] = model_paths[key]
+            if "learn_in_w" not in self.opts[key]:
+                self.opts[key]["learn_in_w"] = False
+            if "output_size" not in self.opts[key]:
+                self.opts[key]["output_size"] = 1024
+
+        self.transforms = {}
+        for key in model_paths.keys():
+            if key in ["ffhq_frontalize", "toonify"]:
+                self.transforms[key] = transforms.Compose(
+                    [
+                        transforms.Resize((256, 256)),
+                        transforms.ToTensor(),
+                        transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),
+                    ]
+                )
+            elif key == "celebs_sketch_to_face":
+                self.transforms[key] = transforms.Compose(
+                    [transforms.Resize((256, 256)), transforms.ToTensor()]
+                )
+            elif key == "celebs_super_resolution":
+                self.transforms[key] = transforms.Compose(
+                    [
+                        transforms.Resize((256, 256)),
+                        augmentations.BilinearResize(factors=[16]),
+                        transforms.Resize((256, 256)),
+                        transforms.ToTensor(),
+                        transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),
+                    ]
+                )
+
     def predict(
         self,
-        input_face,
-        pretrained,
-        style_img_0,
-        style_img_1,
-        style_img_2,
-        style_img_3,
-        preserve_color,
-        num_iter,
-        alpha,
-    ):
+        image: Path = Input(description="input image"),
+        model: str = Input(
+            choices=[
+                "celebs_sketch_to_face",
+                "ffhq_frontalize",
+                "celebs_super_resolution",
+                "toonify",
+            ],
+            description="choose model type",
+        ),
+    ) -> Path:
+        opts = self.opts[model]
+        opts = Namespace(**opts)
+        pprint.pprint(opts)
 
-        device = "cuda"  # 'cuda' or 'cpu'
+        net = pSp(opts)
+        net.eval()
+        net.cuda()
+        print("Model successfully loaded!")
 
-        latent_dim = 512
-
-        # Load original generator
-        original_generator = Generator(1024, latent_dim, 8, 2).to(device)
-        ckpt = torch.load(
-            "models/stylegan2-ffhq-config-f.pt",
-            map_location=lambda storage, loc: storage,
-        )
-        original_generator.load_state_dict(ckpt["g_ema"], strict=False)
-
-        # to be finetuned generator
-        generator = deepcopy(original_generator)
-
-        transform = transforms.Compose(
-            [
-                transforms.Resize((1024, 1024)),
-                transforms.ToTensor(),
-                transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
-            ]
-        )
-
-        # aligns and crops face
-        aligned_face = align_face(str(input_face))
-
-        my_w = e4e_projection(aligned_face, "input_face.pt", device).unsqueeze(0)
-
-        if pretrained is not None:
-            if (
-                preserve_color
-                and not (pretrained == "art")
-                and not (pretrained == "sketch_multi")
-            ):
-                ckpt = f"{pretrained}_preserve_color.pt"
-            else:
-                ckpt = f"{pretrained}.pt"
-
-            ckpt = torch.load(
-                os.path.join("models", ckpt), map_location=lambda storage, loc: storage
-            )
-            generator.load_state_dict(ckpt["g"], strict=False)
-
-            with torch.no_grad():
-                generator.eval()
-                stylized_face = generator(my_w, input_is_latent=True)
-
+        original_image = Image.open(str(image))
+        if opts.label_nc == 0:
+            original_image = original_image.convert("RGB")
         else:
-            # finetune with new style images
-            targets = []
-            latents = []
+            original_image = original_image.convert("L")
+        original_image.resize(
+            (self.opts[model]["output_size"], self.opts[model]["output_size"])
+        )
 
-            style_imgs = [style_img_0, style_img_1, style_img_2, style_img_3]
+        # Align Image
+        if model not in ["celebs_sketch_to_face", "celebs_seg_to_face"]:
+            input_image = self.run_alignment(str(image))
+        else:
+            input_image = original_image
 
-            # Remove None values
-            style_imgs = [i for i in style_imgs if i]
+        img_transforms = self.transforms[model]
+        transformed_image = img_transforms(input_image)
 
-            for ind, style_img in enumerate(style_imgs):
+        if model in ["celebs_sketch_to_face", "celebs_seg_to_face"]:
+            latent_mask = [8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+        else:
+            latent_mask = None
 
-                # crop and align the face
-                style_aligned = align_face(str(style_img))
+        with torch.no_grad():
+            result_image = run_on_batch(
+                transformed_image.unsqueeze(0), net, latent_mask
+            )[0]
+        input_vis_image = log_input_image(transformed_image, opts)
+        output_image = tensor2im(result_image)
 
-                out_path = f"style_aligned_{ind}.jpg"
-                style_aligned.save(str(out_path))
-
-                # GAN invert
-                latent = e4e_projection(style_aligned, f"style_img_{ind}.pt", device)
-
-                targets.append(transform(style_aligned).to(device))
-                latents.append(latent.to(device))
-
-            targets = torch.stack(targets, 0)
-            latents = torch.stack(latents, 0)
-
-            alpha = 1 - alpha
-            # load discriminator for perceptual loss
-            discriminator = Discriminator(1024, 2).eval().to(device)
-            ckpt = torch.load(
-                "models/stylegan2-ffhq-config-f.pt",
-                map_location=lambda storage, loc: storage,
+        if model == "celebs_super_resolution":
+            res = np.concatenate(
+                [
+                    np.array(
+                        input_vis_image.resize(
+                            (
+                                self.opts[model]["output_size"],
+                                self.opts[model]["output_size"],
+                            )
+                        )
+                    ),
+                    np.array(
+                        output_image.resize(
+                            (
+                                self.opts[model]["output_size"],
+                                self.opts[model]["output_size"],
+                            )
+                        )
+                    ),
+                ],
+                axis=1,
             )
-            discriminator.load_state_dict(ckpt["d"], strict=False)
-
-            g_optim = optim.Adam(generator.parameters(), lr=2e-3, betas=(0, 0.99))
-
-            # Which layers to swap for generating a family of plausible real images -> fake image
-            if preserve_color:
-                id_swap = [9, 11, 15, 16, 17]
-            else:
-                id_swap = list(range(7, generator.n_latent))
-
-            for idx in tqdm(range(num_iter)):
-                mean_w = (
-                    generator.get_latent(
-                        torch.randn([latents.size(0), latent_dim]).to(device)
-                    )
-                    .unsqueeze(1)
-                    .repeat(1, generator.n_latent, 1)
+        else:
+            res = np.array(
+                output_image.resize(
+                    (self.opts[model]["output_size"], self.opts[model]["output_size"])
                 )
-                in_latent = latents.clone()
-                in_latent[:, id_swap] = (
-                    alpha * latents[:, id_swap] + (1 - alpha) * mean_w[:, id_swap]
-                )
+            )
 
-                img = generator(in_latent, input_is_latent=True)
-
-                with torch.no_grad():
-                    real_feat = discriminator(targets)
-                fake_feat = discriminator(img)
-
-                loss = sum(
-                    [F.l1_loss(a, b) for a, b in zip(fake_feat, real_feat)]
-                ) / len(fake_feat)
-
-                g_optim.zero_grad()
-                loss.backward()
-                g_optim.step()
-
-            with torch.no_grad():
-                generator.eval()
-                stylized_face = generator(my_w, input_is_latent=True)
-
-        stylized_face = stylized_face.cpu()
-        np.save("stylized_face.npy", stylized_face)
-
-        stylized_face = 1 + stylized_face
-        stylized_face /= 2
-
-        stylized_face = stylized_face[0]
-        stylized_face = 255 * torch.clip(stylized_face, min=0, max=1)
-        stylized_face = stylized_face.byte()
-
-        stylized_face = stylized_face.permute(1, 2, 0).detach().numpy()
-        stylized_face = Image.fromarray(stylized_face, mode="RGB")
-        out_path = Path(tempfile.mkdtemp()) / "out.jpg"
-        stylized_face.save(str(out_path))
-
+        out_path = Path(tempfile.mkdtemp()) / "out.png"
+        Image.fromarray(np.array(res)).save(str(out_path))
         return out_path
+
+    def run_alignment(self, image_path):
+        aligned_image = align_face(filepath=image_path, predictor=self.predictor)
+        print("Aligned image has shape: {}".format(aligned_image.size))
+        return aligned_image
+
+
+def run_on_batch(inputs, net, latent_mask=None):
+    if latent_mask is None:
+        result_batch = net(inputs.to("cuda").float(), randomize_noise=False)
+    else:
+        result_batch = []
+        for image_idx, input_image in enumerate(inputs):
+            # get latent vector to inject into our input image
+            vec_to_inject = np.random.randn(1, 512).astype("float32")
+            _, latent_to_inject = net(
+                torch.from_numpy(vec_to_inject).to("cuda"),
+                input_code=True,
+                return_latents=True,
+            )
+            # get output image with injected style vector
+            res = net(
+                input_image.unsqueeze(0).to("cuda").float(),
+                latent_mask=latent_mask,
+                inject_latent=latent_to_inject,
+                resize=False,
+            )
+            result_batch.append(res)
+        result_batch = torch.cat(result_batch, dim=0)
+    return result_batch


### PR DESCRIPTION
The [new version of Cog](https://github.com/replicate/cog/releases/tag/v0.1.0) improves the Python API, along with several other changes. Particularly pydantic is now used for Predictor and the previous version will be deprecated.  

This PR upgrades the Replicate demo and API to Cog version >= 0.1. I have already pushed this to Replicate, so you don't need to do anything for the demo to keep working :)
https://replicate.com/mchong6/jojogan